### PR TITLE
Scaffold RouteFlow London project with caching client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+.prisma
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Rfl
+# RouteFlow London
+
+This repository contains an early scaffold for **RouteFlow London**, a community‑friendly transit app for London's buses.
+
+The aim of this scaffold is to provide:
+
+- Minimal Next.js‑style file structure (`app/` directory) with placeholder pages.
+- A simple TfL API client with in‑memory caching for stop searches and arrivals.
+- Prisma schema describing core domain tables.
+- Node built‑in test verifying the caching logic.
+
+> Full project vision, roadmap, and feature breakdown can be found in the `docs/` folder.
+
+## Scripts
+
+- `npm test` – run the node test suite.
+
+## Environment
+
+The project intentionally avoids external npm dependencies so it can run in restricted environments. API routes and pages are illustrative and rely only on the Node.js runtime.

--- a/app/api/stops/[id]/arrivals/route.js
+++ b/app/api/stops/[id]/arrivals/route.js
@@ -1,0 +1,8 @@
+import { getStopArrivals } from '../../../../../lib/tfl.js';
+
+export async function GET(request, { params }) {
+  const data = await getStopArrivals(params.id);
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/app/api/stops/search/route.js
+++ b/app/api/stops/search/route.js
@@ -1,0 +1,13 @@
+import { searchStops } from '../../../../lib/tfl.js';
+
+export async function GET(request) {
+  const { searchParams } = new URL(request.url);
+  const q = searchParams.get('q');
+  if (!q) {
+    return new Response(JSON.stringify({ error: 'Missing q' }), { status: 400 });
+  }
+  const data = await searchStops(q);
+  return new Response(JSON.stringify(data), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/app/page.js
+++ b/app/page.js
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <main>
+      <h1>RouteFlow London</h1>
+      <p>Dashboard placeholder.</p>
+    </main>
+  );
+}

--- a/app/search/page.js
+++ b/app/search/page.js
@@ -1,0 +1,8 @@
+export default function SearchPage() {
+  return (
+    <main>
+      <h1>Search</h1>
+      <p>Search page placeholder.</p>
+    </main>
+  );
+}

--- a/app/stops/[id]/page.js
+++ b/app/stops/[id]/page.js
@@ -1,0 +1,8 @@
+export default function StopPage({ params }) {
+  return (
+    <main>
+      <h1>Stop {params.id}</h1>
+      <p>Stop detail placeholder.</p>
+    </main>
+  );
+}

--- a/docs/BLUEPRINT.md
+++ b/docs/BLUEPRINT.md
@@ -1,0 +1,22 @@
+# RouteFlow London – Product & Technical Blueprint
+
+This document summarises the long‑term vision for RouteFlow London, a modern transit app focused on London buses.
+
+It covers:
+
+1. **Vision & Goals** – fast live data, delightful UI, deep route & fleet information.
+2. **Personas** – commuters, enthusiasts, visitors.
+3. **Feature Set** – live tracking, journey planning, disruptions, fleet list, current & withdrawn routes, gamification, accounts, dashboard.
+4. **Tech Stack** – Next.js frontend, Node.js API, PostgreSQL via Prisma, Redis cache, Auth.js, SSE/WebSockets.
+5. **Data Sources** – TfL APIs, curated datasets, community fleet data with caching & background jobs.
+6. **Domain Model** – detailed schema for users, favourites, routes, stops, fleet, gamification.
+7. **API Design** – REST endpoints for stops, routes, journeys, fleet, gamification, accounts.
+8. **Frontend IA** – dashboard, search, stop detail, route detail, journey planner, fleet explorer, withdrawn routes archive, profile, leaderboard.
+9. **Gamification Mechanics** – XP formula, levels, streaks, anti‑abuse measures.
+10. **Security & Privacy** – minimal PII, Argon2 hashing, rate limiting, consent prompts.
+11. **Performance & Reliability** – caching, backpressure, graceful degradation.
+12. **Admin & Moderation** – dashboard, audit log.
+13. **Roadmap & Milestones** – phased delivery from foundations to journey planner & map.
+14. **Initial Tasks** – DB schema, TfL client, stop search & arrivals routes, route sync job, disruptions fetcher, auth, favourites, gamification skeleton, admin scaffold.
+
+Additional sections outline future expansions (knowledge hub, profile notes, Discord integration, etc.). See the project discussion for full details.

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,0 +1,5 @@
+// Prisma client placeholder. Normally you would import {PrismaClient} from '@prisma/client'
+// and export a singleton instance. This file exists to show where database
+// access would live in a full environment with dependencies available.
+
+export const prisma = {};

--- a/lib/tfl.js
+++ b/lib/tfl.js
@@ -1,0 +1,54 @@
+/**
+ * Minimal TfL API client with in-memory caching.
+ * Uses the public TfL API (https://api.tfl.gov.uk) and caches results
+ * for a short time to reduce repeated calls.
+ */
+
+const BASE_URL = 'https://api.tfl.gov.uk';
+const cache = new Map();
+
+function getCache(key) {
+  const entry = cache.get(key);
+  if (!entry) return null;
+  if (entry.exp < Date.now()) {
+    cache.delete(key);
+    return null;
+  }
+  return entry.data;
+}
+
+function setCache(key, data, ttlMs) {
+  cache.set(key, { data, exp: Date.now() + ttlMs });
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
+  return res.json();
+}
+
+export async function searchStops(query) {
+  const key = `search:${query}`;
+  const cached = getCache(key);
+  if (cached) return cached;
+  const data = await fetchJson(`${BASE_URL}/StopPoint/Search?query=${encodeURIComponent(query)}`);
+  setCache(key, data, 12 * 60 * 60 * 1000); // 12h
+  return data;
+}
+
+export async function getStopArrivals(id) {
+  const key = `arrivals:${id}`;
+  const cached = getCache(key);
+  if (cached) return cached;
+  const data = await fetchJson(`${BASE_URL}/StopPoint/${id}/Arrivals`);
+  setCache(key, data, 10 * 1000); // 10s
+  return data;
+}
+
+export function _cacheSize() {
+  return cache.size;
+}
+
+export function _clearCache() {
+  cache.clear();
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "routeflow-london",
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,187 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(uuid())
+  email         String   @unique
+  emailVerified DateTime? @map("email_verified_at")
+  passwordHash  String?  @map("password_hash")
+  displayName   String?  @map("display_name")
+  avatarUrl     String?  @map("avatar_url")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @default(now()) @map("updated_at")
+  sessions      Session[]
+  favourites    Favourite[]
+  alerts        Alert[]
+  userXp        UserXp?
+  achievements  UserAchievement[]
+}
+
+model Session {
+  id         String   @id @default(uuid())
+  user       User     @relation(fields: [userId], references: [id])
+  userId     String   @map("user_id")
+  createdAt  DateTime @default(now()) @map("created_at")
+  lastSeenAt DateTime? @map("last_seen_at")
+}
+
+model Favourite {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @map("user_id")
+  favType   String   @map("fav_type")
+  refId     String   @map("ref_id")
+  label     String?
+  createdAt DateTime @default(now()) @map("created_at")
+}
+
+model Alert {
+  id        String   @id @default(uuid())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String   @map("user_id")
+  alertType String   @map("alert_type")
+  criteria  Json
+  isActive  Boolean  @default(true) @map("is_active")
+  createdAt DateTime @default(now()) @map("created_at")
+}
+
+model Operator {
+  id       String   @id
+  name     String
+  groups   String[]
+  boroughs String[]
+  depots   String[]
+  routes   Route[]
+  vehicles Vehicle[]
+}
+
+model Route {
+  id         String   @id
+  name       String?
+  mode       String?
+  operator   Operator? @relation(fields: [operatorId], references: [id])
+  operatorId String?
+  origin     String?
+  destination String?
+  isNight    Boolean @default(false) @map("is_night")
+  isSchool   Boolean @default(false) @map("is_school")
+  metadata   Json?
+  active     Boolean @default(true)
+  stops      StopSequence[]
+  disruptions Disruption[]
+  sightings  Sighting[]
+}
+
+model Stop {
+  id          String   @id
+  name        String?
+  platformName String? @map("platform_name")
+  lat         Float?
+  lon         Float?
+  indicators  String[]
+  lines       String[]
+  borough     String?
+  zone        String?
+  metadata    Json?
+  sequences   StopSequence[]
+  disruptions Disruption[]
+  sightings   Sighting[]
+}
+
+model StopSequence {
+  id        BigInt  @id @default(autoincrement())
+  route     Route   @relation(fields: [routeId], references: [id])
+  routeId   String  @map("route_id")
+  direction String
+  sequence  Int
+  stop      Stop    @relation(fields: [stopId], references: [id])
+  stopId    String  @map("stop_id")
+}
+
+model Disruption {
+  id        String   @id
+  route     Route?   @relation(fields: [routeId], references: [id])
+  routeId   String?  @map("route_id")
+  stop      Stop?    @relation(fields: [stopId], references: [id])
+  stopId    String?  @map("stop_id")
+  title     String?
+  category  String?
+  severity  String?
+  description String?
+  startTime DateTime? @map("start_time")
+  endTime   DateTime? @map("end_time")
+  raw       Json?
+}
+
+model Vehicle {
+  id         String   @id @default(uuid())
+  operator   Operator? @relation(fields: [operatorId], references: [id])
+  operatorId String?   @map("operator_id")
+  fleetNumber String?  @map("fleet_number")
+  registration String?
+  make        String?
+  model       String?
+  year        Int?
+  depot       String?
+  notes       String?
+  isActive    Boolean @default(true) @map("is_active")
+  metadata    Json?
+  sightings   Sighting[]
+}
+
+model Sighting {
+  id        String   @id @default(uuid())
+  vehicle   Vehicle  @relation(fields: [vehicleId], references: [id])
+  vehicleId String   @map("vehicle_id")
+  route     Route?   @relation(fields: [routeId], references: [id])
+  routeId   String?  @map("route_id")
+  stop      Stop?    @relation(fields: [stopId], references: [id])
+  stopId    String?  @map("stop_id")
+  observedAt DateTime @map("observed_at")
+  source    String
+  raw       Json?
+}
+
+model WithdrawnRoute {
+  id         String @id
+  name       String?
+  origin     String?
+  destination String?
+  startDate  DateTime? @map("start_date")
+  endDate    DateTime? @map("end_date")
+  reason     String?
+  successorIds String[] @map("successor_ids")
+}
+
+model Achievement {
+  id          String @id
+  name        String
+  description String?
+  icon        String?
+  rules       Json?
+  users       UserAchievement[]
+}
+
+model UserXp {
+  user        User   @relation(fields: [userId], references: [id])
+  userId      String @id @map("user_id")
+  xp          Int    @default(0)
+  level       Int    @default(1)
+  streakDays  Int    @default(0) @map("streak_days")
+  lastCheckin DateTime? @map("last_checkin")
+}
+
+model UserAchievement {
+  user        User       @relation(fields: [userId], references: [id])
+  userId      String     @map("user_id")
+  achievement Achievement @relation(fields: [achievementId], references: [id])
+  achievementId String   @map("achievement_id")
+  earnedAt   DateTime    @map("earned_at")
+  @@id([userId, achievementId])
+}

--- a/test/tfl.test.js
+++ b/test/tfl.test.js
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { getStopArrivals, searchStops, _clearCache } from '../lib/tfl.js';
+
+// Mock fetch for tests
+const originalFetch = global.fetch;
+
+function mockResponse(data) {
+  return Promise.resolve(new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  }));
+}
+
+test('getStopArrivals caches data for 10 seconds', async () => {
+  let calls = 0;
+  global.fetch = () => { calls++; return mockResponse([]); };
+  _clearCache();
+  await getStopArrivals('123');
+  await getStopArrivals('123');
+  assert.strictEqual(calls, 1, 'second call uses cache');
+  const realNow = Date.now;
+  Date.now = () => realNow() + 11000; // advance time 11s
+  await getStopArrivals('123');
+  assert.strictEqual(calls, 2, 'after ttl fetch called again');
+  Date.now = realNow;
+  global.fetch = originalFetch;
+});
+
+test('searchStops caches data for 12 hours', async () => {
+  let calls = 0;
+  global.fetch = () => { calls++; return mockResponse({ matches: [] }); };
+  _clearCache();
+  await searchStops('oxford');
+  await searchStops('oxford');
+  assert.strictEqual(calls, 1, 'second search uses cache');
+  const realNow = Date.now;
+  Date.now = () => realNow() + 13 * 60 * 60 * 1000; // +13h
+  await searchStops('oxford');
+  assert.strictEqual(calls, 2, 'after ttl fetch called again');
+  Date.now = realNow;
+  global.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add Node project skeleton with `app/` pages and REST-style API routes
- implement minimal TfL API client with in-memory caching
- document long-term blueprint and add Prisma schema for core tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b11a92c08322a39ee719239d225d