### PR TITLE
Add static Netlify-ready portal

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,0 +1,1483 @@
+const PRIORITY_SCORES = {
+  staff: 4,
+  supporter: 3,
+  standard: 2,
+  guest: 1
+};
+
+const PRIORITY_SPEEDUP_MINUTES = {
+  staff: 10,
+  supporter: 6,
+  standard: 0,
+  guest: 0
+};
+
+const ADMIN_CREDENTIALS = {
+  username: 'command',
+  password: 'apex-admin'
+};
+
+const CHECKOUT_WINDOW_MINUTES = 15;
+const MAX_CHECKOUT_QUANTITY = 10;
+const DEFAULT_TEBEX_BASE = 'https://store.apexrp.example';
+
+const state = {
+  banner: {
+    title: 'Apex Roleplay Network',
+    tagline: 'Professional FiveM storytelling with a committed staff team and thriving community.',
+    callout: 'Now recruiting dedicated emergency services and gang leadership roles.'
+  },
+  joinSteps: [
+    'Join our Discord and link your Steam account in #server-identity.',
+    'Read the community handbook and watch the onboarding video.',
+    'Submit the appropriate application form below and schedule your interview.',
+    'Install FiveM, add the Apex RP server to your favourites, and prepare your character dossier.'
+  ],
+  rules: {
+    roleplay: [
+      {
+        id: 'rp-1',
+        title: 'Stay in character',
+        description:
+          'Your character should make believable decisions. Avoid breaking immersion or referencing out-of-character knowledge during scenes.'
+      },
+      {
+        id: 'rp-2',
+        title: 'Escalate with intent',
+        description:
+          'Conflict must be story-driven. Provide opportunities for retaliation or negotiation before violence, and respect value-of-life expectations.'
+      },
+      {
+        id: 'rp-3',
+        title: 'Respect scene control',
+        description:
+          'Follow directions from scene leads such as command staff or event runners. Use /ooc for quick clarifications only when necessary.'
+      }
+    ],
+    community: [
+      {
+        id: 'com-1',
+        title: 'Zero tolerance harassment',
+        description:
+          'Discrimination, hate speech, and targeted harassment are instant bans. Treat every player and staff member with respect on all platforms.'
+      },
+      {
+        id: 'com-2',
+        title: 'Discord professionalism',
+        description:
+          'Use proper channels for questions, reports, and suggestions. Follow ticket templates so staff can resolve issues quickly.'
+      },
+      {
+        id: 'com-3',
+        title: 'Content policy',
+        description:
+          'Streaming or sharing content from Apex RP requires appropriate tags and compliance with Twitch/YouTube community guidelines.'
+      }
+    ]
+  },
+  news: [
+    {
+      id: 'news-1',
+      title: '1.7 City Update deployed',
+      excerpt: 'Drug laboratories, new MDT for LEO, and rebuilt hospital interior are now live.',
+      body:
+        'Our latest patch introduces modular drug labs, an expanded MDT for the LSPD, and an EMS trauma overhaul. Read the changelog for bug fixes and developer notes.',
+      publishedAt: '2024-05-22T18:00:00Z',
+      author: 'Development Team'
+    },
+    {
+      id: 'news-2',
+      title: 'Summer whitelist drive',
+      excerpt: 'Applications for story-driven civilians are open with fast-tracked review windows.',
+      body:
+        'We are searching for storytellers who enjoy collaborative RP. Submit your whitelist dossier and attend an orientation session hosted twice per week.',
+      publishedAt: '2024-06-10T21:30:00Z',
+      author: 'Staff Command'
+    },
+    {
+      id: 'news-3',
+      title: 'Faction shake-ups & recruitment',
+      excerpt: 'Mechanic unions, nightlife ownership, and new gang opportunities are on the horizon.',
+      body:
+        'Business proposals and gang pitches are now reviewed in the staff portal. Bring a unique angle—economy-focused, community-driven RP receives priority consideration.',
+      publishedAt: '2024-06-28T16:15:00Z',
+      author: 'Community Management'
+    }
+  ],
+  jobs: [
+    {
+      id: 'job-police',
+      name: 'Los Santos Police Department',
+      description:
+        'Structured patrols, investigations, and tactical responses with full MDT, evidence, and courtroom support.',
+      focus: 'Patrol | Investigations | Command ladder',
+      icon: '🚓'
+    },
+    {
+      id: 'job-ems',
+      name: 'Los Santos Medical Services',
+      description:
+        'Advanced trauma response, field triage, and hospital roleplay with a custom patient care system.',
+      focus: 'Rescue | Healing | Training',
+      icon: '🚑'
+    },
+    {
+      id: 'job-mechanic',
+      name: 'Mechanics & Tuners',
+      description:
+        'Own a shop, manage stock, and provide roadside rescue. Includes custom tuning UI and tow fleet.',
+      focus: 'Business | Economy | Crafting',
+      icon: '🛠️'
+    },
+    {
+      id: 'job-gang',
+      name: 'Gangs & Crime',
+      description:
+        'Organise sophisticated operations, maintain turf, and negotiate with crews across the city under staff oversight.',
+      focus: 'Strategy | Storytelling | Territory',
+      icon: '🦈'
+    },
+    {
+      id: 'job-civ',
+      name: 'Civilians & Entrepreneurs',
+      description:
+        'Launch nightclubs, run media crews, or deliver experiences like extreme sports events.',
+      focus: 'Creativity | Events | Social',
+      icon: '🎭'
+    }
+  ],
+  gallery: [
+    {
+      id: 'gallery-1',
+      title: 'City skyline patrol',
+      type: 'image',
+      url: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=1200&q=80'
+    },
+    {
+      id: 'gallery-2',
+      title: 'Hospital grand re-opening',
+      type: 'image',
+      url: 'https://images.unsplash.com/photo-1504439904031-93ded9f93e4e?auto=format&fit=crop&w=1200&q=80'
+    },
+    {
+      id: 'gallery-3',
+      title: 'Community street festival',
+      type: 'image',
+      url: 'https://images.unsplash.com/photo-1492684223066-81342ee5ff30?auto=format&fit=crop&w=1200&q=80'
+    },
+    {
+      id: 'gallery-4',
+      title: 'Emergency services training day',
+      type: 'image',
+      url: 'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80'
+    }
+  ],
+  applications: [
+    {
+      id: 'app-1',
+      role: 'whitelist',
+      characterName: 'Nova Ridge',
+      discord: 'NovaRidge#2244',
+      experience: 'Serious RP for 3 years, civilian and EMS lines.',
+      availability: 'EU evenings',
+      motivation: 'Looking to build business RP and coordinate community events.',
+      status: 'pending',
+      submittedAt: '2024-06-25T18:30:00Z'
+    },
+    {
+      id: 'app-2',
+      role: 'police',
+      characterName: 'Jordan Voss',
+      discord: 'Voss#1881',
+      experience: 'Former Sgt. in DOJRP, familiar with penal code and report writing.',
+      availability: 'US afternoons & weekends',
+      motivation: 'Excited to mentor cadets and help stand up detective bureau.',
+      status: 'pending',
+      submittedAt: '2024-06-22T02:00:00Z'
+    },
+    {
+      id: 'app-3',
+      role: 'ems',
+      characterName: 'Skyler Dune',
+      discord: 'SkyDune#1020',
+      experience: 'Registered EMT, played EMS on multiple FiveM servers.',
+      availability: 'US late nights',
+      motivation: 'Wants to expand trauma scenarios and create medical storylines.',
+      status: 'approved',
+      submittedAt: '2024-06-10T20:10:00Z'
+    }
+  ],
+  supportTickets: [
+    {
+      id: 'ticket-1',
+      subject: 'Whitelist interview scheduling',
+      user: 'Lyric',
+      channel: 'Discord',
+      status: 'open',
+      createdAt: '2024-06-26T14:45:00Z'
+    },
+    {
+      id: 'ticket-2',
+      subject: 'Refund request - vehicle duplication',
+      user: 'Catalina',
+      channel: 'Web',
+      status: 'pending',
+      createdAt: '2024-06-24T19:10:00Z'
+    },
+    {
+      id: 'ticket-3',
+      subject: 'Gang strike appeal',
+      user: 'Trace',
+      channel: 'Discord',
+      status: 'resolved',
+      createdAt: '2024-06-15T23:00:00Z'
+    }
+  ],
+  comments: [
+    {
+      id: 'comment-1',
+      user: 'Trace',
+      message: 'Huge props to the EMS team, training day was incredible.',
+      status: 'published',
+      submittedAt: '2024-06-18T12:15:00Z'
+    },
+    {
+      id: 'comment-2',
+      user: 'Aria',
+      message: 'Please review the tuner shop exploit, cars are disappearing.',
+      status: 'flagged',
+      submittedAt: '2024-06-20T21:45:00Z'
+    }
+  ],
+  discordSettings: {
+    guildId: '112233445566778899',
+    channelId: '998877665544332211'
+  },
+  queue: {
+    active: [
+      {
+        id: '1',
+        playerName: 'NovaRift',
+        steamId: 'steam:11000010c0ffee',
+        role: 'LSPD Sergeant',
+        priority: 'staff',
+        notes: "Coordinating tonight's patrol.",
+        joinedAt: new Date(Date.now() - 12 * 60000)
+      },
+      {
+        id: '2',
+        playerName: 'Lyric',
+        steamId: 'steam:1100001088beef',
+        role: 'EMS Chief',
+        priority: 'supporter',
+        notes: 'On duty, trauma team ready.',
+        joinedAt: new Date(Date.now() - 9 * 60000)
+      },
+      {
+        id: '3',
+        playerName: 'Catalina',
+        steamId: 'steam:1100001099abcd',
+        role: 'Civilian Entrepreneur',
+        priority: 'standard',
+        notes: 'Hosting a Vespucci Beach market.',
+        joinedAt: new Date(Date.now() - 7 * 60000)
+      },
+      {
+        id: '4',
+        playerName: 'Trace',
+        steamId: 'steam:11000010fff1234',
+        role: 'Street Racer',
+        priority: 'guest',
+        notes: 'Fresh from whitelist orientation.',
+        joinedAt: new Date(Date.now() - 4 * 60000)
+      }
+    ],
+    history: [],
+    processed: 48
+  },
+  serverStatus: {
+    state: 'Online',
+    playersOnline: 182,
+    maxPlayers: 350,
+    queueLength: 4,
+    uptime: '18h 42m',
+    lastRestart: 'Today 09:00 UTC',
+    address: 'fivem://apexroleplay'
+  },
+  storeItems: [
+    {
+      id: 'store-1',
+      packageId: 4101,
+      name: 'Priority Supporter',
+      description: 'Queue priority, supporter role, and monthly merch raffle entry.',
+      price: '£12.00',
+      priceValue: { amount: 12, currency: 'GBP' },
+      active: true,
+      platform: 'Tebex',
+      category: 'Support'
+    },
+    {
+      id: 'store-2',
+      packageId: 4125,
+      name: 'Gang Package',
+      description: 'Faction toolkit review with staff, custom spray, and stash upgrades.',
+      price: '£45.00',
+      priceValue: { amount: 45, currency: 'GBP' },
+      active: true,
+      platform: 'Tebex',
+      category: 'Faction'
+    },
+    {
+      id: 'store-3',
+      name: 'One-time Donation',
+      description: 'Support server costs via PayPal. Includes Discord donor tag.',
+      price: 'Custom',
+      priceValue: null,
+      active: true,
+      platform: 'PayPal',
+      donateUrl: 'https://paypal.me/apexrp'
+    }
+  ],
+  purchaseState: {},
+  adminUser: null,
+  adminFilters: {
+    applicationRole: 'all'
+  },
+  applicationFeedback: '',
+  supportFeedback: ''
+};
+
+const counters = {
+  news: state.news.length + 1,
+  gallery: state.gallery.length + 1,
+  applications: state.applications.length + 1,
+  tickets: state.supportTickets.length + 1
+};
+
+const applicationRoleCards = [
+  {
+    id: 'role-whitelist',
+    title: 'Whitelist',
+    description: 'Baseline access to the city. Required before any other applications.'
+  },
+  {
+    id: 'role-police',
+    title: 'Police',
+    description: 'Structured academy, SOP exams, and mentorship with command staff.'
+  },
+  {
+    id: 'role-ems',
+    title: 'EMS',
+    description: 'Comprehensive medical training, hospital RP, and rescue operations.'
+  },
+  {
+    id: 'role-mechanic',
+    title: 'Mechanic',
+    description: 'Manage shop inventory, tuning upgrades, and roadside assistance.'
+  },
+  {
+    id: 'role-staff',
+    title: 'Staff',
+    description: 'Moderation, event curation, and application reviews for trusted members.'
+  }
+];
+
+function formatDate(value) {
+  const date = new Date(value);
+  return date.toLocaleString('en-GB', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+}
+
+function statusClass(status) {
+  switch (status) {
+    case 'approved':
+    case 'resolved':
+      return 'status-pill status-pill--approved';
+    case 'denied':
+      return 'status-pill status-pill--denied';
+    case 'pending':
+      return 'status-pill status-pill--pending';
+    case 'open':
+      return 'status-pill status-pill--open';
+    default:
+      return 'status-pill';
+  }
+}
+
+function sortQueue() {
+  state.queue.active.sort((a, b) => {
+    const scoreDelta = (PRIORITY_SCORES[b.priority] || 0) - (PRIORITY_SCORES[a.priority] || 0);
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+    return a.joinedAt.getTime() - b.joinedAt.getTime();
+  });
+}
+
+function minutesBetween(now, joinedAt) {
+  return Math.max(1, Math.round((now - joinedAt) / 60000));
+}
+
+function calculateQueueStats() {
+  sortQueue();
+  const now = Date.now();
+  const active = state.queue.active.map((entry, index) => {
+    const waitedMinutes = minutesBetween(now, entry.joinedAt.getTime());
+    const base = (index + 1) * 5;
+    const speedup = PRIORITY_SPEEDUP_MINUTES[entry.priority] || 0;
+    const etaMinutes = Math.max(waitedMinutes, Math.max(3, base - speedup));
+    return {
+      ...entry,
+      position: index + 1,
+      waitedMinutes,
+      etaMinutes
+    };
+  });
+
+  const totalWait = active.reduce((acc, entry) => acc + entry.waitedMinutes, 0);
+  const priorityBreakdown = active.reduce((acc, entry) => {
+    const key = entry.priority || 'standard';
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {});
+
+  return {
+    activeCount: active.length,
+    processedCount: state.queue.processed,
+    averageWait: active.length ? Math.round(totalWait / active.length) : 0,
+    longestWait: active.reduce((max, entry) => Math.max(max, entry.waitedMinutes), 0),
+    priorityBreakdown,
+    active
+  };
+}
+
+function renderHero() {
+  document.getElementById('hero-title').textContent = state.banner.title;
+  document.getElementById('hero-tagline').textContent = state.banner.tagline;
+  document.getElementById('hero-callout').textContent = state.banner.callout;
+}
+
+function renderJoinSteps() {
+  const list = document.getElementById('join-steps');
+  list.innerHTML = '';
+  state.joinSteps.forEach((step) => {
+    const li = document.createElement('li');
+    li.textContent = step;
+    list.appendChild(li);
+  });
+}
+
+function renderRules() {
+  const roleplayList = document.getElementById('rule-roleplay');
+  const communityList = document.getElementById('rule-community');
+  roleplayList.innerHTML = '';
+  communityList.innerHTML = '';
+
+  state.rules.roleplay.forEach((rule) => {
+    const li = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = rule.title;
+    const span = document.createElement('span');
+    span.textContent = rule.description;
+    li.append(strong, span);
+    roleplayList.appendChild(li);
+  });
+
+  state.rules.community.forEach((rule) => {
+    const li = document.createElement('li');
+    const strong = document.createElement('strong');
+    strong.textContent = rule.title;
+    const span = document.createElement('span');
+    span.textContent = rule.description;
+    li.append(strong, span);
+    communityList.appendChild(li);
+  });
+}
+
+function renderNews() {
+  const container = document.getElementById('news-grid');
+  container.innerHTML = '';
+  state.news.forEach((item) => {
+    const article = document.createElement('article');
+    article.className = 'news-item';
+
+    const time = document.createElement('time');
+    time.textContent = formatDate(item.publishedAt);
+
+    const heading = document.createElement('h3');
+    heading.textContent = item.title;
+
+    const excerpt = document.createElement('p');
+    excerpt.textContent = item.excerpt;
+
+    article.append(time, heading, excerpt);
+
+    if (item.body) {
+      const body = document.createElement('p');
+      body.textContent = item.body;
+      article.appendChild(body);
+    }
+
+    const small = document.createElement('small');
+    small.textContent = `Posted by ${item.author}`;
+    article.appendChild(small);
+
+    container.appendChild(article);
+  });
+}
+
+function renderJobs() {
+  const container = document.getElementById('jobs-grid');
+  container.innerHTML = '';
+  state.jobs.forEach((job) => {
+    const card = document.createElement('article');
+    card.className = 'job-card';
+
+    const icon = document.createElement('span');
+    icon.textContent = job.icon;
+
+    const heading = document.createElement('h3');
+    heading.textContent = job.name;
+
+    const description = document.createElement('p');
+    description.textContent = job.description;
+
+    const focus = document.createElement('small');
+    focus.textContent = job.focus;
+
+    card.append(icon, heading, description, focus);
+    container.appendChild(card);
+  });
+}
+
+function renderGallery() {
+  const container = document.getElementById('gallery-grid');
+  container.innerHTML = '';
+  state.gallery.forEach((item) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'gallery-item';
+
+    if (item.type === 'video') {
+      const frame = document.createElement('iframe');
+      frame.title = item.title;
+      frame.src = item.url;
+      frame.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+      frame.allowFullscreen = true;
+      wrapper.appendChild(frame);
+    } else {
+      const img = document.createElement('img');
+      img.src = item.url;
+      img.alt = item.title;
+      wrapper.appendChild(img);
+    }
+
+    const caption = document.createElement('span');
+    caption.className = 'gallery-item__caption';
+    caption.textContent = item.title;
+    wrapper.appendChild(caption);
+
+    if (item.type) {
+      const badge = document.createElement('small');
+      badge.textContent = item.type;
+      badge.style.position = 'absolute';
+      badge.style.top = '0.75rem';
+      badge.style.left = '0.75rem';
+      badge.style.background = 'rgba(5,7,15,0.65)';
+      badge.style.padding = '0.2rem 0.5rem';
+      badge.style.borderRadius = '0.6rem';
+      wrapper.appendChild(badge);
+    }
+
+    container.appendChild(wrapper);
+  });
+}
+
+function renderApplicationRoles() {
+  const container = document.getElementById('application-roles');
+  container.innerHTML = '';
+  applicationRoleCards.forEach((role) => {
+    const card = document.createElement('article');
+    card.className = 'card';
+    const heading = document.createElement('h3');
+    heading.textContent = role.title;
+    const paragraph = document.createElement('p');
+    paragraph.textContent = role.description;
+    card.append(heading, paragraph);
+    container.appendChild(card);
+  });
+}
+
+function renderQueueMetrics() {
+  const stats = calculateQueueStats();
+  state.serverStatus.queueLength = stats.activeCount;
+
+  document.getElementById('queue-waiting').textContent = `${stats.activeCount} players waiting`;
+  document.getElementById('queue-average').textContent = `Avg wait ${stats.averageWait} min · Served ${stats.processedCount}`;
+  const breakdown = stats.priorityBreakdown;
+  document.getElementById('queue-priority').textContent = `Priority mix: staff ${breakdown.staff || 0} · supporter ${
+    breakdown.supporter || 0
+  } · standard ${breakdown.standard || 0}`;
+
+  const server = state.serverStatus;
+  document.getElementById('server-state').textContent = server.state;
+  document.getElementById('server-population').textContent = `${server.playersOnline}/${server.maxPlayers} online · Queue ${
+    server.queueLength
+  }`;
+  document.getElementById('server-uptime').textContent = `Uptime ${server.uptime}`;
+  document.getElementById('server-restart').textContent = `Last restart ${server.lastRestart}`;
+  document.getElementById('server-address').textContent = `Connect: ${server.address}`;
+  document.getElementById('server-peak').textContent = server.maxPlayers;
+  document.getElementById('footer-address').textContent = server.address;
+}
+
+function renderStore() {
+  const container = document.getElementById('store-grid');
+  container.innerHTML = '';
+
+  state.storeItems.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = 'card';
+
+    const heading = document.createElement('h3');
+    heading.textContent = item.name;
+    card.appendChild(heading);
+
+    const description = document.createElement('p');
+    description.textContent = item.description;
+    card.appendChild(description);
+
+    const price = document.createElement('strong');
+    price.textContent = item.price;
+    card.appendChild(price);
+
+    if (item.packageId) {
+      const packageTag = document.createElement('span');
+      packageTag.textContent = `Package #${item.packageId}`;
+      card.appendChild(packageTag);
+    }
+
+    const platform = document.createElement('span');
+    platform.textContent = `Platform: ${item.platform}`;
+    card.appendChild(platform);
+
+    const status = document.createElement('span');
+    status.textContent = `Status: ${item.active ? 'Available' : 'Hidden'}`;
+    card.appendChild(status);
+
+    if (item.platform === 'Tebex' && item.active) {
+      const form = document.createElement('form');
+      form.className = 'tebex-form';
+
+      const usernameLabel = document.createElement('label');
+      usernameLabel.textContent = 'Character / IGN';
+      const usernameInput = document.createElement('input');
+      usernameInput.name = 'username';
+      usernameInput.placeholder = 'Nova Ridge';
+      usernameInput.required = true;
+      usernameLabel.appendChild(usernameInput);
+
+      const emailLabel = document.createElement('label');
+      emailLabel.textContent = 'Contact email (optional)';
+      const emailInput = document.createElement('input');
+      emailInput.name = 'email';
+      emailInput.type = 'email';
+      emailInput.placeholder = 'you@example.com';
+      emailLabel.appendChild(emailInput);
+
+      const quantityLabel = document.createElement('label');
+      quantityLabel.textContent = 'Quantity';
+      const quantityInput = document.createElement('input');
+      quantityInput.name = 'quantity';
+      quantityInput.type = 'number';
+      quantityInput.min = '1';
+      quantityInput.max = String(MAX_CHECKOUT_QUANTITY);
+      quantityInput.value = '1';
+      quantityLabel.appendChild(quantityInput);
+
+      const submitButton = document.createElement('button');
+      submitButton.className = 'button button--primary';
+      submitButton.type = 'submit';
+      submitButton.textContent =
+        state.purchaseState[item.id]?.status === 'loading' ? 'Creating checkout…' : 'Purchase via Tebex';
+
+      if (state.purchaseState[item.id]?.status === 'loading') {
+        submitButton.disabled = true;
+      }
+
+      form.append(usernameLabel, emailLabel, quantityLabel, submitButton);
+
+      form.addEventListener('submit', (event) => handleTebexPurchase(event, item));
+
+      card.appendChild(form);
+
+      const feedbackState = state.purchaseState[item.id];
+      if (feedbackState?.status === 'success') {
+        const feedback = document.createElement('div');
+        feedback.className = 'purchase-feedback purchase-feedback--success';
+        const message =
+          feedbackState.message || 'Checkout created. Complete your purchase in the Tebex tab.';
+        if (feedbackState.redirectUrl) {
+          const text = document.createElement('span');
+          text.textContent = `${message} `;
+          const link = document.createElement('a');
+          link.href = feedbackState.redirectUrl;
+          link.target = '_blank';
+          link.rel = 'noreferrer';
+          link.textContent = 'Open Tebex checkout';
+          feedback.append(text, link);
+        } else {
+          feedback.textContent = message;
+        }
+        card.appendChild(feedback);
+      } else if (feedbackState?.status === 'error') {
+        const feedback = document.createElement('div');
+        feedback.className = 'purchase-feedback purchase-feedback--error';
+        feedback.textContent = feedbackState.message;
+        card.appendChild(feedback);
+      }
+    } else {
+      const actions = document.createElement('div');
+      actions.className = 'admin-actions';
+      const link = document.createElement('a');
+      link.href = item.donateUrl || DEFAULT_TEBEX_BASE;
+      link.target = '_blank';
+      link.rel = 'noreferrer';
+      link.textContent = 'Open store';
+      actions.appendChild(link);
+      card.appendChild(actions);
+    }
+
+    container.appendChild(card);
+  });
+}
+
+function renderDiscord() {
+  const frame = document.getElementById('discord-embed');
+  frame.src = `https://discord.com/widget?id=${state.discordSettings.guildId}&theme=dark`;
+}
+
+function renderSupportStats() {
+  const open = state.supportTickets.filter((ticket) => ticket.status === 'open').length;
+  const pending = state.supportTickets.filter((ticket) => ticket.status === 'pending').length;
+  const resolved = state.supportTickets.filter((ticket) => ticket.status === 'resolved').length;
+  const total = state.supportTickets.length;
+
+  document.getElementById('ticket-open').textContent = open;
+  document.getElementById('ticket-pending').textContent = pending;
+  document.getElementById('ticket-resolved').textContent = resolved;
+  document.getElementById('ticket-total').textContent = total;
+}
+
+function renderFeedback(id, message) {
+  const element = document.getElementById(id);
+  if (!element) return;
+  if (message) {
+    element.textContent = message;
+    element.hidden = false;
+  } else {
+    element.textContent = '';
+    element.hidden = true;
+  }
+}
+
+function renderAdminPanel() {
+  const login = document.getElementById('admin-login');
+  const panel = document.getElementById('admin-panel');
+  if (state.adminUser) {
+    login.hidden = true;
+    panel.hidden = false;
+    document.getElementById('admin-welcome').textContent = `Welcome back, ${state.adminUser.username}. Manage the city below.`;
+    renderAdminStats();
+    renderAdminNews();
+    renderAdminRules();
+    renderAdminGallery();
+    renderAdminApplications();
+    renderAdminTickets();
+    renderAdminComments();
+    renderAdminStoreControls();
+    populateServerForm();
+    populateDiscordForm();
+  } else {
+    login.hidden = false;
+    panel.hidden = true;
+    document.getElementById('login-error').hidden = true;
+  }
+}
+
+function renderAdminStats() {
+  const applications = state.applications;
+  const pending = applications.filter((app) => app.status === 'pending').length;
+  const approved = applications.filter((app) => app.status === 'approved').length;
+  const denied = applications.filter((app) => app.status === 'denied').length;
+  const total = applications.length;
+  const openTickets = state.supportTickets.filter((ticket) => ticket.status === 'open').length;
+  const flaggedComments = state.comments.filter((comment) => comment.status === 'flagged').length;
+
+  document.getElementById('admin-app-total').textContent = total;
+  document.getElementById('admin-app-pending').textContent = pending;
+  document.getElementById('admin-app-approved').textContent = approved;
+  document.getElementById('admin-app-denied').textContent = denied;
+  document.getElementById('admin-ticket-open').textContent = openTickets;
+  document.getElementById('admin-comments-flagged').textContent = flaggedComments;
+}
+
+function renderAdminNews() {
+  const container = document.getElementById('admin-news-grid');
+  container.innerHTML = '';
+
+  state.news.forEach((item) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'news-item';
+
+    const titleLabel = document.createElement('label');
+    titleLabel.textContent = 'Headline';
+    const titleInput = document.createElement('input');
+    titleInput.value = item.title;
+    titleInput.addEventListener('input', (event) => {
+      item.title = event.target.value;
+      renderNews();
+    });
+    titleLabel.appendChild(titleInput);
+
+    const summaryLabel = document.createElement('label');
+    summaryLabel.textContent = 'Summary';
+    const summaryInput = document.createElement('input');
+    summaryInput.value = item.excerpt;
+    summaryInput.addEventListener('input', (event) => {
+      item.excerpt = event.target.value;
+      renderNews();
+    });
+    summaryLabel.appendChild(summaryInput);
+
+    const bodyLabel = document.createElement('label');
+    bodyLabel.textContent = 'Body';
+    const bodyInput = document.createElement('textarea');
+    bodyInput.value = item.body || '';
+    bodyInput.addEventListener('input', (event) => {
+      item.body = event.target.value;
+      renderNews();
+    });
+    bodyLabel.appendChild(bodyInput);
+
+    const meta = document.createElement('small');
+    meta.textContent = `Published ${formatDate(item.publishedAt)} · ${item.author}`;
+
+    wrapper.append(titleLabel, summaryLabel, bodyLabel, meta);
+    container.appendChild(wrapper);
+  });
+}
+
+function renderAdminRules() {
+  const container = document.getElementById('admin-rules');
+  container.innerHTML = '';
+
+  ['roleplay', 'community'].forEach((group) => {
+    const card = document.createElement('div');
+    card.className = 'card';
+    card.style.background = 'rgba(12,16,31,0.6)';
+
+    const heading = document.createElement('h4');
+    heading.textContent = group === 'roleplay' ? 'Roleplay standards' : 'Community conduct';
+    card.appendChild(heading);
+
+    state.rules[group].forEach((rule) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'admin-actions';
+      wrapper.style.alignItems = 'stretch';
+      wrapper.style.flexDirection = 'column';
+
+      const titleLabel = document.createElement('label');
+      titleLabel.textContent = 'Title';
+      const titleInput = document.createElement('input');
+      titleInput.value = rule.title;
+      titleInput.addEventListener('input', (event) => {
+        rule.title = event.target.value;
+        renderRules();
+      });
+      titleLabel.appendChild(titleInput);
+
+      const descriptionLabel = document.createElement('label');
+      descriptionLabel.textContent = 'Description';
+      const descriptionInput = document.createElement('textarea');
+      descriptionInput.value = rule.description;
+      descriptionInput.addEventListener('input', (event) => {
+        rule.description = event.target.value;
+        renderRules();
+      });
+      descriptionLabel.appendChild(descriptionInput);
+
+      wrapper.append(titleLabel, descriptionLabel);
+      card.appendChild(wrapper);
+    });
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'button button--ghost';
+    addButton.textContent = group === 'roleplay' ? 'Add RP rule' : 'Add community rule';
+    addButton.addEventListener('click', () => {
+      const id = `${group}-${Date.now()}`;
+      state.rules[group].push({
+        id,
+        title: 'New rule',
+        description: 'Describe the guideline here.'
+      });
+      renderRules();
+      renderAdminRules();
+    });
+    card.appendChild(addButton);
+
+    container.appendChild(card);
+  });
+}
+
+function renderAdminGallery() {
+  const container = document.getElementById('admin-gallery-grid');
+  container.innerHTML = '';
+
+  state.gallery.forEach((item) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'gallery-item';
+
+    if (item.type === 'video') {
+      const frame = document.createElement('iframe');
+      frame.title = item.title;
+      frame.src = item.url;
+      frame.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+      frame.allowFullscreen = true;
+      wrapper.appendChild(frame);
+    } else {
+      const img = document.createElement('img');
+      img.src = item.url;
+      img.alt = item.title;
+      wrapper.appendChild(img);
+    }
+
+    const caption = document.createElement('span');
+    caption.className = 'gallery-item__caption';
+    caption.textContent = item.title;
+    wrapper.appendChild(caption);
+
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'button button--ghost';
+    remove.textContent = 'Remove';
+    remove.style.position = 'absolute';
+    remove.style.top = '0.75rem';
+    remove.style.right = '0.75rem';
+    remove.addEventListener('click', () => {
+      state.gallery = state.gallery.filter((entry) => entry.id !== item.id);
+      renderGallery();
+      renderAdminGallery();
+    });
+    wrapper.appendChild(remove);
+
+    container.appendChild(wrapper);
+  });
+}
+
+function filteredApplications() {
+  if (state.adminFilters.applicationRole === 'all') {
+    return state.applications.slice();
+  }
+  return state.applications.filter((app) => app.role === state.adminFilters.applicationRole);
+}
+
+function renderAdminApplications() {
+  const tbody = document.querySelector('#admin-app-table tbody');
+  tbody.innerHTML = '';
+  const apps = filteredApplications();
+  document.getElementById('admin-app-count').textContent = `${apps.length} results`;
+  document.getElementById('admin-app-filter').value = state.adminFilters.applicationRole;
+
+  apps.forEach((app) => {
+    const row = document.createElement('tr');
+
+    const roleCell = document.createElement('td');
+    roleCell.textContent = app.role;
+
+    const characterCell = document.createElement('td');
+    const strong = document.createElement('strong');
+    strong.textContent = app.characterName;
+    const details = document.createElement('div');
+    details.textContent = app.motivation || app.experience || '';
+    characterCell.append(strong, details);
+
+    const discordCell = document.createElement('td');
+    discordCell.textContent = app.discord;
+
+    const submittedCell = document.createElement('td');
+    submittedCell.textContent = formatDate(app.submittedAt);
+
+    const statusCell = document.createElement('td');
+    const status = document.createElement('span');
+    status.className = statusClass(app.status);
+    status.textContent = app.status;
+    statusCell.appendChild(status);
+
+    const actionsCell = document.createElement('td');
+    const actions = document.createElement('div');
+    actions.className = 'admin-actions';
+
+    const approve = document.createElement('button');
+    approve.type = 'button';
+    approve.textContent = 'Approve';
+    approve.addEventListener('click', () => updateApplicationStatus(app.id, 'approved'));
+
+    const deny = document.createElement('button');
+    deny.type = 'button';
+    deny.textContent = 'Deny';
+    deny.addEventListener('click', () => updateApplicationStatus(app.id, 'denied'));
+
+    const reset = document.createElement('button');
+    reset.type = 'button';
+    reset.textContent = 'Reset';
+    reset.addEventListener('click', () => updateApplicationStatus(app.id, 'pending'));
+
+    actions.append(approve, deny, reset);
+    actionsCell.appendChild(actions);
+
+    row.append(roleCell, characterCell, discordCell, submittedCell, statusCell, actionsCell);
+    tbody.appendChild(row);
+  });
+}
+
+function renderAdminTickets() {
+  const tbody = document.querySelector('#admin-ticket-table tbody');
+  tbody.innerHTML = '';
+  state.supportTickets.forEach((ticket) => {
+    const row = document.createElement('tr');
+
+    const idCell = document.createElement('td');
+    idCell.textContent = ticket.id;
+
+    const subjectCell = document.createElement('td');
+    subjectCell.textContent = ticket.subject;
+
+    const userCell = document.createElement('td');
+    userCell.textContent = ticket.user;
+
+    const channelCell = document.createElement('td');
+    channelCell.textContent = ticket.channel;
+
+    const createdCell = document.createElement('td');
+    createdCell.textContent = formatDate(ticket.createdAt);
+
+    const statusCell = document.createElement('td');
+    const status = document.createElement('span');
+    status.className = statusClass(ticket.status);
+    status.textContent = ticket.status;
+    statusCell.appendChild(status);
+
+    const actionsCell = document.createElement('td');
+    const actions = document.createElement('div');
+    actions.className = 'admin-actions';
+
+    const markOpen = document.createElement('button');
+    markOpen.type = 'button';
+    markOpen.textContent = 'Mark open';
+    markOpen.addEventListener('click', () => updateTicketStatus(ticket.id, 'open'));
+
+    const pending = document.createElement('button');
+    pending.type = 'button';
+    pending.textContent = 'Pending';
+    pending.addEventListener('click', () => updateTicketStatus(ticket.id, 'pending'));
+
+    const resolve = document.createElement('button');
+    resolve.type = 'button';
+    resolve.textContent = 'Resolve';
+    resolve.addEventListener('click', () => updateTicketStatus(ticket.id, 'resolved'));
+
+    actions.append(markOpen, pending, resolve);
+    actionsCell.appendChild(actions);
+
+    row.append(idCell, subjectCell, userCell, channelCell, createdCell, statusCell, actionsCell);
+    tbody.appendChild(row);
+  });
+}
+
+function renderAdminComments() {
+  const container = document.getElementById('admin-comments');
+  container.innerHTML = '';
+  state.comments.forEach((comment) => {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'admin-actions';
+    wrapper.style.alignItems = 'stretch';
+    wrapper.style.flexDirection = 'column';
+
+    const strong = document.createElement('strong');
+    strong.textContent = comment.user;
+    const message = document.createElement('span');
+    message.textContent = comment.message;
+    const meta = document.createElement('small');
+    meta.textContent = `Submitted ${formatDate(comment.submittedAt)}`;
+
+    const actions = document.createElement('div');
+    actions.className = 'admin-actions';
+
+    const status = document.createElement('span');
+    status.className = statusClass(comment.status);
+    status.textContent = comment.status;
+
+    const publish = document.createElement('button');
+    publish.type = 'button';
+    publish.textContent = 'Publish';
+    publish.addEventListener('click', () => moderateComment(comment.id, 'published'));
+
+    const flag = document.createElement('button');
+    flag.type = 'button';
+    flag.textContent = 'Flag';
+    flag.addEventListener('click', () => moderateComment(comment.id, 'flagged'));
+
+    const resolve = document.createElement('button');
+    resolve.type = 'button';
+    resolve.textContent = 'Resolve';
+    resolve.addEventListener('click', () => moderateComment(comment.id, 'resolved'));
+
+    actions.append(status, publish, flag, resolve);
+    wrapper.append(strong, message, meta, actions);
+    container.appendChild(wrapper);
+  });
+}
+
+function renderAdminStoreControls() {
+  const container = document.getElementById('admin-store');
+  container.innerHTML = '';
+  state.storeItems.forEach((item) => {
+    const row = document.createElement('div');
+    row.className = 'admin-actions';
+    const label = document.createElement('span');
+    label.textContent = `${item.name} — ${item.active ? 'Active' : 'Hidden'}`;
+    const toggle = document.createElement('button');
+    toggle.type = 'button';
+    toggle.textContent = 'Toggle';
+    toggle.addEventListener('click', () => {
+      item.active = !item.active;
+      renderStore();
+      renderAdminStoreControls();
+    });
+    row.append(label, toggle);
+    container.appendChild(row);
+  });
+}
+
+function populateServerForm() {
+  const form = document.getElementById('server-form');
+  form.state.value = state.serverStatus.state;
+  form.playersOnline.value = state.serverStatus.playersOnline;
+  form.maxPlayers.value = state.serverStatus.maxPlayers;
+  form.queueLength.value = state.serverStatus.queueLength;
+  form.uptime.value = state.serverStatus.uptime;
+  form.lastRestart.value = state.serverStatus.lastRestart;
+  form.address.value = state.serverStatus.address;
+}
+
+function populateDiscordForm() {
+  const form = document.getElementById('discord-form');
+  form.guildId.value = state.discordSettings.guildId;
+  form.channelId.value = state.discordSettings.channelId;
+}
+
+function handleApplicationSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const characterName = String(formData.get('characterName') || '').trim();
+  const discord = String(formData.get('discord') || '').trim();
+  if (!characterName || !discord) {
+    state.applicationFeedback = 'Please provide both a character name and Discord handle.';
+    renderFeedback('application-feedback', state.applicationFeedback);
+    return;
+  }
+
+  const entry = {
+    id: `app-${counters.applications++}`,
+    role: formData.get('role'),
+    characterName,
+    discord,
+    experience: String(formData.get('experience') || '').trim(),
+    availability: String(formData.get('availability') || '').trim(),
+    motivation: String(formData.get('motivation') || '').trim(),
+    status: 'pending',
+    submittedAt: new Date().toISOString()
+  };
+
+  state.applications.unshift(entry);
+  state.applicationFeedback = 'Application received. A staff member will reach out on Discord once it has been reviewed.';
+  renderFeedback('application-feedback', state.applicationFeedback);
+  form.reset();
+
+  renderAdminStats();
+  renderAdminApplications();
+}
+
+function handleSupportSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const subject = String(formData.get('subject') || '').trim();
+  if (!subject) {
+    state.supportFeedback = 'Please add a subject so the team knows how to help.';
+    renderFeedback('support-feedback', state.supportFeedback);
+    return;
+  }
+
+  const ticket = {
+    id: `ticket-${counters.tickets++}`,
+    subject,
+    user: String(formData.get('contact') || '').trim() || 'Anonymous',
+    channel: String(formData.get('channel') || 'Discord'),
+    status: 'open',
+    createdAt: new Date().toISOString()
+  };
+
+  state.supportTickets.unshift(ticket);
+  state.supportFeedback = 'Support ticket created. Track updates in your Discord DMs or email.';
+  renderFeedback('support-feedback', state.supportFeedback);
+  form.reset();
+
+  renderSupportStats();
+  renderAdminStats();
+  renderAdminTickets();
+}
+
+function handleLogin(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const username = String(formData.get('username') || '').trim().toLowerCase();
+  const password = formData.get('password');
+
+  if (username === ADMIN_CREDENTIALS.username && password === ADMIN_CREDENTIALS.password) {
+    state.adminUser = { username: formData.get('username').trim() };
+    form.reset();
+    renderAdminPanel();
+  } else {
+    const error = document.getElementById('login-error');
+    error.textContent = 'Invalid credentials. Contact lead staff if you need access.';
+    error.hidden = false;
+  }
+}
+
+function handleLogout() {
+  state.adminUser = null;
+  renderAdminPanel();
+}
+
+function handleServerForm(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const playersOnlineValue = Number(formData.get('playersOnline'));
+  const maxPlayersValue = Number(formData.get('maxPlayers'));
+  const queueLengthValue = Number(formData.get('queueLength'));
+  state.serverStatus = {
+    state: formData.get('state') || state.serverStatus.state,
+    playersOnline:
+      Number.isFinite(playersOnlineValue) && formData.get('playersOnline') !== ''
+        ? playersOnlineValue
+        : state.serverStatus.playersOnline,
+    maxPlayers:
+      Number.isFinite(maxPlayersValue) && formData.get('maxPlayers') !== ''
+        ? maxPlayersValue
+        : state.serverStatus.maxPlayers,
+    queueLength:
+      Number.isFinite(queueLengthValue) && formData.get('queueLength') !== ''
+        ? queueLengthValue
+        : state.serverStatus.queueLength,
+    uptime: formData.get('uptime') || state.serverStatus.uptime,
+    lastRestart: formData.get('lastRestart') || state.serverStatus.lastRestart,
+    address: formData.get('address') || state.serverStatus.address
+  };
+  renderQueueMetrics();
+  renderAdminStats();
+}
+
+function handleDiscordForm(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  state.discordSettings = {
+    guildId: formData.get('guildId') || state.discordSettings.guildId,
+    channelId: formData.get('channelId') || state.discordSettings.channelId
+  };
+  renderDiscord();
+}
+
+function updateApplicationStatus(id, status) {
+  state.applications = state.applications.map((app) =>
+    app.id === id
+      ? {
+          ...app,
+          status
+        }
+      : app
+  );
+  renderAdminStats();
+  renderAdminApplications();
+}
+
+function updateTicketStatus(id, status) {
+  state.supportTickets = state.supportTickets.map((ticket) =>
+    ticket.id === id
+      ? {
+          ...ticket,
+          status
+        }
+      : ticket
+  );
+  renderSupportStats();
+  renderAdminStats();
+  renderAdminTickets();
+}
+
+function moderateComment(id, status) {
+  state.comments = state.comments.map((comment) =>
+    comment.id === id
+      ? {
+          ...comment,
+          status
+        }
+      : comment
+  );
+  renderAdminComments();
+  renderAdminStats();
+}
+
+function handleNewsForm(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const title = String(formData.get('title') || '').trim();
+  if (!title) {
+    return;
+  }
+
+  const post = {
+    id: `news-${counters.news++}`,
+    title,
+    excerpt: String(formData.get('excerpt') || '').trim() || title,
+    body: String(formData.get('body') || '').trim(),
+    publishedAt: new Date().toISOString(),
+    author: state.adminUser ? `${state.adminUser.username} (Staff)` : 'Staff Team'
+  };
+
+  state.news.unshift(post);
+  form.reset();
+  renderNews();
+  renderAdminNews();
+}
+
+function handleGalleryForm(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const url = String(formData.get('url') || '').trim();
+  if (!url) {
+    return;
+  }
+
+  const entry = {
+    id: `gallery-${counters.gallery++}`,
+    title: String(formData.get('title') || 'New media asset').trim() || 'New media asset',
+    type: formData.get('type') || 'image',
+    url
+  };
+
+  state.gallery.unshift(entry);
+  form.reset();
+  renderGallery();
+  renderAdminGallery();
+}
+
+function handleTebexPurchase(event, item) {
+  event.preventDefault();
+  const formData = new FormData(event.currentTarget);
+  const username = String(formData.get('username') || '').trim();
+  const email = String(formData.get('email') || '').trim();
+  const quantity = Number(formData.get('quantity') || 1);
+
+  if (!username) {
+    state.purchaseState[item.id] = {
+      status: 'error',
+      message: 'Character name is required to start a checkout.'
+    };
+    renderStore();
+    return;
+  }
+
+  if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_CHECKOUT_QUANTITY) {
+    state.purchaseState[item.id] = {
+      status: 'error',
+      message: `Quantity must be between 1 and ${MAX_CHECKOUT_QUANTITY}.`
+    };
+    renderStore();
+    return;
+  }
+
+  if (email && !/^.+@.+\..+$/.test(email)) {
+    state.purchaseState[item.id] = {
+      status: 'error',
+      message: 'Contact email must be valid.'
+    };
+    renderStore();
+    return;
+  }
+
+  state.purchaseState[item.id] = { status: 'loading' };
+  renderStore();
+
+  const checkoutId = `chk_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const expiresAt = new Date(Date.now() + CHECKOUT_WINDOW_MINUTES * 60 * 1000);
+  const params = new URLSearchParams({
+    package: String(item.packageId),
+    username,
+    quantity: String(quantity)
+  });
+  if (email) {
+    params.set('email', email);
+  }
+  const redirectUrl = `${DEFAULT_TEBEX_BASE.replace(/\/$/, '')}/checkout/${checkoutId}?${params.toString()}`;
+
+  state.purchaseState[item.id] = {
+    status: 'success',
+    message: `Checkout created. Expires ${formatDate(expiresAt)}`,
+    redirectUrl
+  };
+  renderStore();
+}
+
+function handleFilterChange(event) {
+  state.adminFilters.applicationRole = event.target.value;
+  renderAdminApplications();
+}
+
+function init() {
+  renderHero();
+  renderJoinSteps();
+  renderRules();
+  renderNews();
+  renderJobs();
+  renderGallery();
+  renderApplicationRoles();
+  renderQueueMetrics();
+  renderStore();
+  renderDiscord();
+  renderSupportStats();
+  renderAdminPanel();
+
+  document.getElementById('application-form').addEventListener('submit', handleApplicationSubmit);
+  document.getElementById('support-form').addEventListener('submit', handleSupportSubmit);
+  document.getElementById('login-form').addEventListener('submit', handleLogin);
+  document.getElementById('logout-button').addEventListener('click', handleLogout);
+  document.getElementById('server-form').addEventListener('submit', handleServerForm);
+  document.getElementById('discord-form').addEventListener('submit', handleDiscordForm);
+  document.getElementById('news-form').addEventListener('submit', handleNewsForm);
+  document.getElementById('gallery-form').addEventListener('submit', handleGalleryForm);
+  document.getElementById('admin-app-filter').addEventListener('change', handleFilterChange);
+
+  setInterval(renderQueueMetrics, 60 * 1000);
+}
+
+init();

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Apex RP Queue Portal</title>
+    <meta
+      name="description"
+      content="Apex RP queue portal with live status, onboarding, applications, and staff tools."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="page">
+      <nav class="nav">
+        <div class="nav__inner">
+          <a class="brand" href="#home">
+            <span class="brand__logo">AR</span>
+            <span>Apex RP</span>
+          </a>
+          <div class="nav__links">
+            <a class="nav__link" href="#home">Home</a>
+            <a class="nav__link" href="#rules">Rules</a>
+            <a class="nav__link" href="#join">Join</a>
+            <a class="nav__link" href="#apply">Apply</a>
+            <a class="nav__link" href="#donate">Donate</a>
+            <a class="nav__link" href="#discord">Discord</a>
+            <a class="nav__link" href="#admin">Admin</a>
+          </div>
+        </div>
+      </nav>
+
+      <main>
+        <section id="home" class="hero">
+          <div class="hero__content">
+            <span class="hero__badge">Apex Roleplay Network</span>
+            <h1 class="hero__title" id="hero-title"></h1>
+            <p class="hero__subtitle" id="hero-tagline"></p>
+            <p class="hero__subtitle" id="hero-callout"></p>
+            <div class="quick-actions">
+              <a class="button button--primary" href="fivem://connect/apexroleplay">Join the server</a>
+              <a class="button" href="#discord">Discord</a>
+              <a class="button" href="#rules">Rules</a>
+              <a class="button" href="#apply">Applications</a>
+              <a class="button button--ghost" href="#donate">Donate</a>
+            </div>
+          </div>
+          <div class="status-grid">
+            <article class="status-card" id="server-card">
+              <h3>Server status</h3>
+              <strong id="server-state"></strong>
+              <span class="status-card__meta" id="server-population"></span>
+              <span class="status-card__meta" id="server-uptime"></span>
+              <span class="status-card__meta" id="server-restart"></span>
+              <span class="status-card__meta" id="server-address"></span>
+            </article>
+            <article class="status-card" id="queue-card">
+              <h3>Queue metrics</h3>
+              <strong id="queue-waiting"></strong>
+              <span class="status-card__meta" id="queue-average"></span>
+              <span class="status-card__meta" id="queue-priority"></span>
+            </article>
+            <article class="guide">
+              <h3>How to join Apex RP</h3>
+              <ol id="join-steps"></ol>
+            </article>
+          </div>
+        </section>
+
+        <section id="rules">
+          <div class="section-heading">
+            <h2>Rules &amp; Handbook</h2>
+            <p>Keep the city professional, immersive, and respectful. These guidelines are non-negotiable.</p>
+          </div>
+          <div class="rules-grid">
+            <div class="rules-group">
+              <h3>Roleplay Standards</h3>
+              <ul class="rules-list" id="rule-roleplay"></ul>
+            </div>
+            <div class="rules-group">
+              <h3>Community Conduct</h3>
+              <ul class="rules-list" id="rule-community"></ul>
+            </div>
+          </div>
+        </section>
+
+        <section id="news">
+          <div class="section-heading">
+            <h2>Announcements &amp; Changelogs</h2>
+            <p>Stay current with new scripts, rule updates, and city events.</p>
+          </div>
+          <div class="news-grid" id="news-grid"></div>
+        </section>
+
+        <section id="showcase">
+          <div class="section-heading">
+            <h2>City Life &amp; Career Paths</h2>
+            <p>Discover the jobs and activities that define Apex RP. Every path has mentors ready to help.</p>
+          </div>
+          <div class="jobs-grid" id="jobs-grid"></div>
+        </section>
+
+        <section id="gallery">
+          <div class="section-heading">
+            <h2>Media Gallery</h2>
+            <p>Highlights from patrols, community events, and cinematic trailers.</p>
+          </div>
+          <div class="gallery-grid" id="gallery-grid"></div>
+        </section>
+
+        <section id="join">
+          <div class="section-heading">
+            <h2>Ready to Join?</h2>
+            <p>Follow the onboarding checklist and submit your whitelist dossier.</p>
+          </div>
+          <div class="card-grid">
+            <article class="card">
+              <h3>Server quick facts</h3>
+              <ul>
+                <li>Voice: In-game + Discord radio relays</li>
+                <li>Framework: Custom QBCore blend</li>
+                <li>Peak population: <span id="server-peak"></span></li>
+                <li>Region: EU/NA mixed scheduling</li>
+                <li>Interviews hosted weekly</li>
+              </ul>
+            </article>
+            <article class="card">
+              <h3>Whitelist expectations</h3>
+              <p>
+                We seek storytellers who communicate, respect boundaries, and collaborate. Provide detailed answers in your
+                application to help staff learn your style and past experience.
+              </p>
+            </article>
+            <article class="card">
+              <h3>Need assistance?</h3>
+              <p>
+                Hop into #support-tickets or complete the support form below. Staff handle onboarding daily with regionally
+                staggered coverage.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section id="apply">
+          <div class="section-heading">
+            <h2>Applications</h2>
+            <p>Select the path that suits you. All submissions appear instantly in the staff portal for review.</p>
+          </div>
+          <div class="application-roles" id="application-roles"></div>
+          <article class="form-card">
+            <h3>Submit your application</h3>
+            <form id="application-form">
+              <label>
+                Role applying for
+                <select name="role" required>
+                  <option value="whitelist">Whitelist</option>
+                  <option value="police">Police</option>
+                  <option value="ems">EMS</option>
+                  <option value="mechanic">Mechanic</option>
+                  <option value="gang">Gang / Org</option>
+                  <option value="staff">Staff</option>
+                </select>
+              </label>
+              <label>
+                Character name / callsign
+                <input name="characterName" placeholder="Jordan Voss" required />
+              </label>
+              <label>
+                Discord handle
+                <input name="discord" placeholder="username#0001" required />
+              </label>
+              <label>
+                Experience
+                <textarea
+                  name="experience"
+                  placeholder="Previous RP communities, certifications, or relevant background"
+                ></textarea>
+              </label>
+              <label>
+                Availability
+                <input name="availability" placeholder="Weeknights, EU evenings, etc." />
+              </label>
+              <label>
+                Why should we pick you?
+                <textarea name="motivation" placeholder="Share your plans for Apex RP"></textarea>
+              </label>
+              <button class="button button--primary" type="submit">Submit application</button>
+            </form>
+            <div class="feedback" id="application-feedback" hidden></div>
+          </article>
+        </section>
+
+        <section id="donate">
+          <div class="section-heading">
+            <h2>Donations &amp; Store</h2>
+            <p>Support Apex RP through Tebex or PayPal. Every contribution funds servers, scripts, and events.</p>
+          </div>
+          <div class="card-grid" id="store-grid"></div>
+        </section>
+
+        <section id="discord">
+          <div class="section-heading">
+            <h2>Discord &amp; Community</h2>
+            <p>Live widget updates automatically once your account is linked.</p>
+          </div>
+          <article class="discord-card">
+            <p>Join over 8,000 members for alerts, development sneak peeks, and direct staff support.</p>
+            <a class="button button--primary" href="https://discord.gg/apexrp" target="_blank" rel="noreferrer"
+              >Join Discord</a
+            >
+            <div class="discord-embed">
+              <iframe
+                id="discord-embed"
+                title="Apex RP Discord"
+                width="100%"
+                height="100%"
+                allowtransparency="true"
+                sandbox="allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+              ></iframe>
+            </div>
+          </article>
+        </section>
+
+        <section id="support">
+          <div class="section-heading">
+            <h2>Support &amp; Tickets</h2>
+            <p>Need help? Submit a ticket or reach out via Discord for the fastest response.</p>
+          </div>
+          <div class="support-grid">
+            <article class="support-card">
+              <h3>Open a ticket</h3>
+              <form id="support-form">
+                <label>
+                  Subject
+                  <input name="subject" placeholder="Describe your issue" required />
+                </label>
+                <label>
+                  Preferred contact
+                  <input name="contact" placeholder="Discord tag or email" />
+                </label>
+                <label>
+                  Channel
+                  <select name="channel">
+                    <option>Discord</option>
+                    <option>Web</option>
+                    <option>Email</option>
+                  </select>
+                </label>
+                <label>
+                  Details
+                  <textarea name="message" placeholder="Provide as much context as possible"></textarea>
+                </label>
+                <button class="button button--primary" type="submit">Submit ticket</button>
+              </form>
+              <div class="feedback" id="support-feedback" hidden></div>
+            </article>
+            <article class="support-card">
+              <h3>Ticket stats</h3>
+              <p>Open: <span id="ticket-open"></span></p>
+              <p>Pending: <span id="ticket-pending"></span></p>
+              <p>Resolved: <span id="ticket-resolved"></span></p>
+              <p>Total: <span id="ticket-total"></span></p>
+              <p>Staff monitor tickets 24/7 with global coverage.</p>
+            </article>
+            <article class="support-card">
+              <h3>Contact</h3>
+              <p>Email: support@apexrp.example</p>
+              <p>Discord: #support-tickets</p>
+              <p>In-game: /report command</p>
+              <p>Response target: &lt; 6 hours</p>
+            </article>
+          </div>
+        </section>
+
+        <section id="admin" class="admin">
+          <div class="section-heading">
+            <h2>Admin Portal</h2>
+            <p>Secure tools for staff to manage content, applications, and live operations.</p>
+          </div>
+          <div id="admin-login" class="admin-login">
+            <h3>Staff sign-in</h3>
+            <form id="login-form">
+              <label>
+                Username
+                <input name="username" placeholder="command" required />
+              </label>
+              <label>
+                Password
+                <input name="password" type="password" placeholder="••••••••" required />
+              </label>
+              <button class="button button--primary" type="submit">Log in</button>
+            </form>
+            <div class="error" id="login-error" hidden></div>
+            <small
+              >Tip: credentials are seeded for demo access — user <code>command</code>, pass <code>apex-admin</code>.</small
+            >
+          </div>
+          <div id="admin-panel" class="admin-grid" hidden>
+            <div class="admin-actions admin-panel__welcome">
+              <span id="admin-welcome"></span>
+              <button id="logout-button" type="button">Log out</button>
+            </div>
+            <div class="admin-grid__two">
+              <article class="card">
+                <h3>Operational overview</h3>
+                <p>Total applications: <span id="admin-app-total"></span></p>
+                <p>Pending: <span id="admin-app-pending"></span></p>
+                <p>Approved: <span id="admin-app-approved"></span></p>
+                <p>Denied: <span id="admin-app-denied"></span></p>
+                <p>Tickets open: <span id="admin-ticket-open"></span></p>
+                <p>Comments flagged: <span id="admin-comments-flagged"></span></p>
+              </article>
+              <article class="card">
+                <h3>Server status controls</h3>
+                <form id="server-form">
+                  <label>
+                    State
+                    <input name="state" />
+                  </label>
+                  <label>
+                    Players online
+                    <input name="playersOnline" type="number" min="0" />
+                  </label>
+                  <label>
+                    Max players
+                    <input name="maxPlayers" type="number" min="1" />
+                  </label>
+                  <label>
+                    Queue length
+                    <input name="queueLength" type="number" min="0" />
+                  </label>
+                  <label>
+                    Uptime
+                    <input name="uptime" />
+                  </label>
+                  <label>
+                    Last restart
+                    <input name="lastRestart" />
+                  </label>
+                  <label>
+                    Address
+                    <input name="address" />
+                  </label>
+                  <button class="button button--primary" type="submit">Update server status</button>
+                </form>
+              </article>
+            </div>
+            <article class="card">
+              <h3>Announcements management</h3>
+              <form id="news-form">
+                <label>
+                  Title
+                  <input name="title" placeholder="Patch 1.8 deployment" required />
+                </label>
+                <label>
+                  Summary
+                  <input name="excerpt" placeholder="Key takeaways" />
+                </label>
+                <label>
+                  Details
+                  <textarea name="body" placeholder="Full announcement body"></textarea>
+                </label>
+                <button class="button button--primary" type="submit">Publish update</button>
+              </form>
+              <div class="news-grid admin-news-grid" id="admin-news-grid"></div>
+            </article>
+            <article class="card">
+              <h3>Rules editor</h3>
+              <div class="admin-grid__two" id="admin-rules"></div>
+            </article>
+            <article class="card">
+              <h3>Media uploads</h3>
+              <form id="gallery-form">
+                <label>
+                  Title
+                  <input name="title" placeholder="New media asset" />
+                </label>
+                <label>
+                  Type
+                  <select name="type">
+                    <option value="image">Image</option>
+                    <option value="video">Video</option>
+                  </select>
+                </label>
+                <label>
+                  URL
+                  <input name="url" placeholder="https://" required />
+                </label>
+                <button class="button button--primary" type="submit">Add to gallery</button>
+              </form>
+              <div class="gallery-grid admin-gallery-grid" id="admin-gallery-grid"></div>
+            </article>
+            <article class="card">
+              <h3>Applications queue</h3>
+              <div class="admin-actions admin-filter-row">
+                <label>
+                  Filter by role
+                  <select id="admin-app-filter">
+                    <option value="all">All</option>
+                    <option value="whitelist">Whitelist</option>
+                    <option value="police">Police</option>
+                    <option value="ems">EMS</option>
+                    <option value="mechanic">Mechanic</option>
+                    <option value="gang">Gang</option>
+                    <option value="staff">Staff</option>
+                  </select>
+                </label>
+                <span id="admin-app-count"></span>
+              </div>
+              <div class="table-wrapper">
+                <table id="admin-app-table">
+                  <thead>
+                    <tr>
+                      <th>Role</th>
+                      <th>Character</th>
+                      <th>Discord</th>
+                      <th>Submitted</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </article>
+            <article class="card">
+              <h3>Support tickets</h3>
+              <div class="table-wrapper">
+                <table id="admin-ticket-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Subject</th>
+                      <th>User</th>
+                      <th>Channel</th>
+                      <th>Created</th>
+                      <th>Status</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody></tbody>
+                </table>
+              </div>
+            </article>
+            <article class="card">
+              <h3>Community moderation</h3>
+              <div id="admin-comments"></div>
+            </article>
+            <article class="card">
+              <h3>Discord embed</h3>
+              <form id="discord-form">
+                <label>
+                  Guild ID
+                  <input name="guildId" />
+                </label>
+                <label>
+                  Channel ID
+                  <input name="channelId" />
+                </label>
+                <button class="button button--primary" type="submit">Update Discord embed</button>
+              </form>
+              <h4>Store availability</h4>
+              <div id="admin-store"></div>
+            </article>
+          </div>
+        </section>
+      </main>
+
+      <footer>
+        <strong>Apex RP · Professional FiveM roleplay</strong>
+        <small>Server IP: <span id="footer-address"></span> · Discord: discord.gg/apexrp · Tebex: store.apexrp.example</small>
+        <small>
+          Admin portal updates sync instantly with live pages. For issues email leadership@apexrp.example.
+        </small>
+      </footer>
+    </div>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,667 @@
+:root {
+    color-scheme: dark;
+    font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+    background: #05070f;
+    color: #f4f6ff;
+  }
+
+  *, *::before, *::after {
+    box-sizing: border-box;
+  }
+
+  body {
+    margin: 0;
+    background: radial-gradient(circle at top left, rgba(83, 109, 254, 0.2), transparent 45%),
+      radial-gradient(circle at bottom right, rgba(255, 90, 145, 0.2), transparent 40%),
+      #05070f;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    gap: 5rem;
+    padding-bottom: 6rem;
+  }
+
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: rgba(5, 7, 15, 0.82);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid rgba(148, 159, 255, 0.18);
+  }
+
+  .nav__inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.1rem clamp(1.5rem, 4vw, 4rem);
+    gap: 1.5rem;
+  }
+
+  .brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.9rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #9fa8ff;
+  }
+
+  .brand__logo {
+    width: 44px;
+    height: 44px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, #536dff, #ff5991);
+    display: grid;
+    place-items: center;
+    font-size: 1.1rem;
+    color: #05070f;
+    font-weight: 800;
+  }
+
+  .nav__links {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .nav__link {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    color: rgba(244, 246, 255, 0.82);
+    border: 1px solid transparent;
+    transition: border-color 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  }
+
+  .nav__link:hover {
+    color: #ffffff;
+    border-color: rgba(148, 159, 255, 0.4);
+    transform: translateY(-1px);
+  }
+
+  main {
+    display: flex;
+    flex-direction: column;
+    gap: 5rem;
+    padding: 0 clamp(1.5rem, 5vw, 5rem);
+  }
+
+  section {
+    display: grid;
+    gap: 2rem;
+  }
+
+  .hero {
+    padding-top: 5rem;
+    display: grid;
+    gap: 3rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: start;
+  }
+
+  .hero__content {
+    display: grid;
+    gap: 1.75rem;
+  }
+
+  .hero__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.4rem 1rem;
+    background: rgba(83, 109, 254, 0.15);
+    color: #9fa8ff;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.75rem;
+    width: fit-content;
+    border: 1px solid rgba(83, 109, 254, 0.3);
+  }
+
+  .hero__title {
+    margin: 0;
+    font-size: clamp(2.5rem, 4vw, 4rem);
+    line-height: 1.1;
+  }
+
+  .hero__subtitle {
+    margin: 0;
+    font-size: 1.1rem;
+    color: rgba(239, 243, 255, 0.78);
+    max-width: 60ch;
+  }
+
+  .quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    padding: 0.85rem 1.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    border: 1px solid transparent;
+    background: rgba(83, 109, 254, 0.18);
+    color: #ffffff;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    box-shadow: 0 15px 35px rgba(83, 109, 254, 0.22);
+  }
+
+  .button--primary {
+    background: linear-gradient(135deg, #536dff, #ff5991);
+    box-shadow: 0 20px 40px rgba(83, 109, 254, 0.28);
+  }
+
+  .button--ghost {
+    background: transparent;
+    border-color: rgba(148, 159, 255, 0.24);
+    box-shadow: none;
+    color: rgba(244, 246, 255, 0.85);
+  }
+
+  .button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 46px rgba(255, 89, 145, 0.3);
+  }
+
+  .status-grid {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .status-card {
+    background: rgba(8, 11, 24, 0.68);
+    border: 1px solid rgba(148, 159, 255, 0.2);
+    padding: 1.4rem;
+    border-radius: 1.2rem;
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .status-card h3 {
+    margin: 0;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: rgba(148, 159, 255, 0.68);
+  }
+
+  .status-card strong {
+    font-size: 1.6rem;
+  }
+
+  .status-card__meta {
+    font-size: 0.85rem;
+    color: rgba(228, 232, 255, 0.72);
+  }
+
+  .guide {
+    background: rgba(8, 11, 24, 0.55);
+    border: 1px solid rgba(148, 159, 255, 0.16);
+    border-radius: 1.2rem;
+    padding: 1.8rem;
+    display: grid;
+    gap: 1.2rem;
+  }
+
+  .guide ol {
+    margin: 0;
+    padding-left: 1.2rem;
+    display: grid;
+    gap: 0.7rem;
+    color: rgba(228, 232, 255, 0.82);
+  }
+
+  .section-heading {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .section-heading h2 {
+    margin: 0;
+    font-size: clamp(1.8rem, 3vw, 2.6rem);
+  }
+
+  .section-heading p {
+    margin: 0;
+    color: rgba(228, 232, 255, 0.78);
+  }
+
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .card {
+    background: rgba(8, 11, 24, 0.6);
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    padding: 1.5rem;
+    border-radius: 1.1rem;
+    display: grid;
+    gap: 0.8rem;
+  }
+
+  .card h3 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .card p {
+    margin: 0;
+    color: rgba(228, 232, 255, 0.75);
+    line-height: 1.5;
+  }
+
+  .rules-grid {
+    display: grid;
+    gap: 1.5rem;
+  }
+
+  .rules-group {
+    display: grid;
+    gap: 1rem;
+    background: rgba(8, 11, 24, 0.55);
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    padding: 1.6rem;
+    border-radius: 1.1rem;
+  }
+
+  .rules-group h3 {
+    margin: 0;
+    font-size: 1.2rem;
+  }
+
+  .rules-list {
+    display: grid;
+    gap: 0.9rem;
+  }
+
+  .rules-list li {
+    padding: 0.8rem 1rem;
+    background: rgba(12, 16, 31, 0.6);
+    border-radius: 0.9rem;
+    border: 1px solid rgba(148, 159, 255, 0.12);
+  }
+
+  .rules-list li strong {
+    display: block;
+    margin-bottom: 0.35rem;
+  }
+
+  .news-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .news-item {
+    display: grid;
+    gap: 0.8rem;
+    background: rgba(8, 11, 24, 0.6);
+    border-radius: 1rem;
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    padding: 1.4rem;
+  }
+
+  .news-item time {
+    font-size: 0.85rem;
+    color: rgba(148, 159, 255, 0.65);
+    letter-spacing: 0.05em;
+  }
+
+  .jobs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.4rem;
+  }
+
+  .job-card {
+    display: grid;
+    gap: 0.7rem;
+    padding: 1.4rem;
+    border-radius: 1.05rem;
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    background: rgba(8, 11, 24, 0.55);
+  }
+
+  .job-card span {
+    font-size: 2rem;
+  }
+
+  .gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .gallery-item {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    min-height: 200px;
+    background: rgba(8, 11, 24, 0.7);
+    border: 1px solid rgba(148, 159, 255, 0.22);
+  }
+
+  .gallery-item img,
+  .gallery-item iframe {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    border: none;
+  }
+
+  .gallery-item__caption {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    background: linear-gradient(0deg, rgba(5, 7, 15, 0.88), transparent 65%);
+    padding: 1rem;
+    font-weight: 600;
+  }
+
+  .application-roles {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+  }
+
+  .form-card {
+    display: grid;
+    gap: 1rem;
+    padding: 1.6rem;
+    border-radius: 1.1rem;
+    border: 1px solid rgba(148, 159, 255, 0.2);
+    background: rgba(8, 11, 24, 0.58);
+  }
+
+  form {
+    display: grid;
+    gap: 1rem;
+  }
+
+  label {
+    display: grid;
+    gap: 0.45rem;
+    font-size: 0.9rem;
+    color: rgba(228, 232, 255, 0.8);
+  }
+
+  input,
+  textarea,
+  select {
+    padding: 0.7rem 0.9rem;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(148, 159, 255, 0.32);
+    background: rgba(5, 7, 15, 0.7);
+    color: #f4f6ff;
+    font: inherit;
+  }
+
+  textarea {
+    resize: vertical;
+    min-height: 120px;
+  }
+
+  .discord-card {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 1.1rem;
+    border: 1px solid rgba(148, 159, 255, 0.2);
+    background: rgba(8, 11, 24, 0.58);
+  }
+
+  .tebex-form {
+    gap: 0.75rem;
+  }
+
+  .tebex-form label {
+    font-size: 0.85rem;
+  }
+
+  .tebex-form input {
+    width: 100%;
+  }
+
+  .tebex-form button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .purchase-feedback {
+    margin-top: 0.8rem;
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+    font-size: 0.9rem;
+  }
+
+  .purchase-feedback--success {
+    background: rgba(83, 109, 254, 0.18);
+    border: 1px solid rgba(83, 109, 254, 0.32);
+    color: rgba(228, 232, 255, 0.95);
+  }
+
+  .purchase-feedback--error {
+    background: rgba(255, 89, 145, 0.18);
+    border: 1px solid rgba(255, 89, 145, 0.32);
+    color: rgba(255, 210, 220, 0.95);
+  }
+
+  .discord-embed {
+    border-radius: 0.9rem;
+    overflow: hidden;
+    border: 1px solid rgba(148, 159, 255, 0.24);
+    min-height: 310px;
+  }
+
+  .support-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .support-card {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: 1.1rem;
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    background: rgba(8, 11, 24, 0.6);
+  }
+
+  .admin {
+    display: grid;
+    gap: 2.5rem;
+    padding-bottom: 4rem;
+  }
+
+  .admin-login {
+    max-width: 420px;
+    background: rgba(8, 11, 24, 0.6);
+    border-radius: 1.2rem;
+    border: 1px solid rgba(148, 159, 255, 0.18);
+    padding: 2rem;
+  }
+
+  .admin-grid {
+    display: grid;
+    gap: 1.7rem;
+  }
+
+  .admin-grid__two {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95rem;
+  }
+
+  table thead th {
+    text-align: left;
+    font-weight: 600;
+    padding: 0.8rem;
+    background: rgba(12, 16, 31, 0.72);
+  }
+
+  table tbody tr:nth-child(even) {
+    background: rgba(8, 11, 24, 0.42);
+  }
+
+  table td {
+    padding: 0.8rem;
+    border-bottom: 1px solid rgba(148, 159, 255, 0.12);
+    vertical-align: top;
+  }
+
+  .status-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    border: 1px solid transparent;
+  }
+
+  .status-pill--pending {
+    background: rgba(255, 187, 92, 0.2);
+    border-color: rgba(255, 187, 92, 0.3);
+    color: #ffbb5c;
+  }
+
+  .status-pill--approved {
+    background: rgba(123, 255, 191, 0.18);
+    border-color: rgba(123, 255, 191, 0.28);
+    color: #8fffbc;
+  }
+
+  .status-pill--denied,
+  .status-pill--resolved {
+    background: rgba(255, 115, 153, 0.18);
+    border-color: rgba(255, 115, 153, 0.28);
+    color: #ff7399;
+  }
+
+  .status-pill--open {
+    background: rgba(83, 109, 254, 0.2);
+    border-color: rgba(83, 109, 254, 0.28);
+    color: #a4adff;
+  }
+
+  .admin-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+  }
+
+  .admin-actions button,
+  .admin-actions a {
+    padding: 0.55rem 1rem;
+    border-radius: 0.7rem;
+    border: 1px solid rgba(148, 159, 255, 0.25);
+    background: rgba(12, 16, 31, 0.7);
+    color: rgba(244, 246, 255, 0.9);
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
+  .admin-actions button:hover,
+  .admin-actions a:hover {
+    border-color: rgba(255, 89, 145, 0.4);
+    color: #ffffff;
+  }
+
+  footer {
+    padding: 3rem clamp(1.5rem, 5vw, 5rem);
+    border-top: 1px solid rgba(148, 159, 255, 0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    background: rgba(5, 7, 15, 0.8);
+  }
+
+  footer small {
+    color: rgba(189, 195, 231, 0.7);
+  }
+
+  .feedback {
+    padding: 0.8rem 1rem;
+    border-radius: 0.8rem;
+    border: 1px solid rgba(123, 255, 191, 0.35);
+    background: rgba(123, 255, 191, 0.1);
+    color: #9fffd0;
+    font-size: 0.9rem;
+  }
+
+  .error {
+    padding: 0.75rem 1rem;
+    border-radius: 0.8rem;
+    border: 1px solid rgba(255, 115, 153, 0.3);
+    background: rgba(255, 115, 153, 0.12);
+    color: #ff99b7;
+    font-size: 0.9rem;
+  }
+
+  @media (max-width: 720px) {
+    .nav__inner {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .nav__links {
+      width: 100%;
+      justify-content: space-between;
+    }
+
+    .hero {
+      padding-top: 3rem;
+    }
+
+    .quick-actions {
+      width: 100%;
+    }
+
+    .button {
+      flex: 1 1 calc(50% - 0.75rem);
+      justify-content: center;
+    }
+
+    .discord-embed {
+      min-height: 260px;
+    }
+  }


### PR DESCRIPTION
## Summary
- add a standalone `static/index.html` mirroring the Apex RP portal structure for static hosting
- extract the UI styling into `static/styles.css` for the Netlify-ready build
- implement `static/app.js` to drive queue metrics, forms, store actions, and the admin tools entirely on the client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d39003e46c832296b280d29304f2ac